### PR TITLE
cleanup: rm redundant find conditional

### DIFF
--- a/lua/paint/highlight.lua
+++ b/lua/paint/highlight.lua
@@ -26,10 +26,8 @@ function M.highlight(buf, first, last)
 
     for _, hl in ipairs(highlights) do
       local from, to, match = line:find(hl.pattern)
-      if from then
-        if match then
-          from, to = line:find(match, from, true)
-        end
+      if match then
+        from, to = line:find(match, from, true)
         vim.api.nvim_buf_set_extmark(
           buf,
           config.ns,


### PR DESCRIPTION
:wave: Cool plugin! 

>  If it finds a match, then find returns the indices of s where this occurrence starts and ends; otherwise, it returns nil. [[1](http://www.lua.org/manual/5.1/manual.html#pdf-string.find)]

If I am understanding correctly, the existing nested `match` check is unnecessary.