### PR TITLE
feat(option): support priority for highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ use({
           filter = { filetype = "lua" },
           pattern = "%s*%-%-%-%s*(@%w+)",
           hl = "Constant",
+          -- priority = 999, --- optional, default is 110
         },
       },
     })

--- a/lua/paint/config.lua
+++ b/lua/paint/config.lua
@@ -10,6 +10,7 @@ M.ns = vim.api.nvim_create_namespace("paint.nvim")
 ---@field filter PaintFilter
 ---@field pattern string
 ---@field hl string
+---@field priority? integer
 
 --- @class PaintOptions
 M.defaults = {

--- a/lua/paint/highlight.lua
+++ b/lua/paint/highlight.lua
@@ -37,7 +37,7 @@ function M.highlight(buf, first, last)
           config.ns,
           lnum - 1,
           from - 1,
-          { end_col = to, hl_group = hl.hl, priority = 110 }
+          { end_col = to, hl_group = hl.hl, priority = hl.priority or 110 }
         )
 
         from, to, match = line:find(hl.pattern, to + 1)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Added support for setting priority of each highlight. This is needed when users want to override/reserve highlights of semantic tokens or treesitter, which may have higher/lower priority than paint.nvim's default value.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
Before (without set priority):
![image](https://github.com/user-attachments/assets/577e7efd-4b55-4c52-adb8-d4e70ad8a106)

After (set priority to 999):
![image](https://github.com/user-attachments/assets/d0d83a96-d0b2-48e5-8f06-e4473d927596)




